### PR TITLE
 #175 global and frame shortcut can now collide

### DIFF
--- a/PS4k/src/com/vitco/layout/WindowManager.java
+++ b/PS4k/src/com/vitco/layout/WindowManager.java
@@ -527,7 +527,7 @@ public class WindowManager extends ExtendedDockableBarDockableHolder implements 
             shortcutManager.registerGlobalShortcutActions();
 
             // load the global hotkeys
-            shortcutManager.registerShortcuts(thisFrame);
+            shortcutManager.registerShortcuts(thisFrame, dockingManager);
 
             // try to load the saved layout
             layoutPersistence.beginLoadLayoutData();

--- a/PS4k/src/com/vitco/layout/content/shortcut/ShortcutManager.java
+++ b/PS4k/src/com/vitco/layout/content/shortcut/ShortcutManager.java
@@ -14,6 +14,7 @@ import com.vitco.manager.error.ErrorHandlerInterface;
 import com.vitco.manager.help.FrameHelpOverlay;
 import com.vitco.manager.lang.LangSelectorInterface;
 import com.vitco.manager.pref.PreferencesInterface;
+import com.vitco.settings.VitcoSettings;
 import com.vitco.util.file.FileTools;
 import com.vitco.util.misc.SaveResourceLoader;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -328,6 +329,39 @@ public class ShortcutManager implements ShortcutManagerInterface {
                 };
             }
             return result;
+        }
+    }
+
+    /* Check if keyStroke is local and collides with global or the other way around */
+    private boolean hasSoftCollision(String frame, KeyStroke keyStroke) {
+        if (frame == null) {
+            // check frame shortcuts for collision
+            for (Collection<ShortcutObject> shortcutObjects : map.values()) {
+                for (ShortcutObject shortcutObject : shortcutObjects) {
+                    if (shortcutObject.keyStroke != null && shortcutObject.keyStroke.equals(keyStroke)) {
+                        return true;
+                    }
+                }
+            }
+        } else {
+            // check global shortcuts for collision
+            for (ShortcutObject shortcutObject : global) {
+                if (shortcutObject.keyStroke != null && shortcutObject.keyStroke.equals(keyStroke)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /* Obtain BG color for a shortcut field that is being edited */
+    @Override
+    public final Color getEditBgColor(String frame, int id) {
+        KeyStroke keyStroke = frame == null ? global.get(id).keyStroke : map.get(frame).get(id).keyStroke;
+        if (hasSoftCollision(frame, keyStroke)) {
+            return VitcoSettings.EDIT_BG_COLOR_HIGHLIGHT;
+        } else {
+            return VitcoSettings.EDIT_BG_COLOR;
         }
     }
 

--- a/PS4k/src/com/vitco/layout/content/shortcut/ShortcutManagerInterface.java
+++ b/PS4k/src/com/vitco/layout/content/shortcut/ShortcutManagerInterface.java
@@ -1,5 +1,6 @@
 package com.vitco.layout.content.shortcut;
 
+import com.jidesoft.docking.DockingManager;
 import com.vitco.manager.action.ActionManager;
 import com.vitco.manager.error.ErrorHandlerInterface;
 import com.vitco.manager.lang.LangSelectorInterface;
@@ -40,5 +41,5 @@ public interface ShortcutManagerInterface {
     void registerGlobalShortcutActions();
 
     // register global shortcuts and make sure all shortcuts are correctly enabled
-    void registerShortcuts(Frame frame);
+    void registerShortcuts(Frame frame, final DockingManager dockingManager);
 }

--- a/PS4k/src/com/vitco/layout/content/shortcut/ShortcutManagerInterface.java
+++ b/PS4k/src/com/vitco/layout/content/shortcut/ShortcutManagerInterface.java
@@ -23,6 +23,7 @@ public interface ShortcutManagerInterface {
     boolean isValidShortcut(KeyStroke keyStroke);
     boolean updateShortcutObject(KeyStroke keyStroke, String frame, int id);
     boolean isFreeShortcut(String frame, KeyStroke keyStroke);
+    Color getEditBgColor(String frame, int id);
     // convert KeyStroke to string representation
     String asString(KeyStroke keyStroke);
     void setErrorHandler(ErrorHandlerInterface errorHandler);

--- a/PS4k/src/com/vitco/layout/content/shortcut/ShortcutManagerView.java
+++ b/PS4k/src/com/vitco/layout/content/shortcut/ShortcutManagerView.java
@@ -94,9 +94,13 @@ public class ShortcutManagerView extends ViewPrototype implements ShortcutManage
                     asyncActionManager.addAsyncAction(new AsyncAction() {
                         @Override
                         public void performAction() {
-                            KeyStroke keyStroke = e.getKeyCode() == 27
-                                    ? null // escape
-                                    : KeyStroke.getKeyStrokeForEvent(e); // else
+                            int keyCode = e.getKeyCode();
+                            if (keyCode == 27) { // escape
+                                stopCellEditing();
+                                return;
+                            }
+                            KeyStroke keyStroke = keyCode == 127 // delete
+                                    ? null : KeyStroke.getKeyStrokeForEvent(e);
                             if (shortcutManager.isValidShortcut(keyStroke)) {
                                 if (shortcutManager.isFreeShortcut(frame, keyStroke)) {
                                     // update the shortcut
@@ -107,7 +111,7 @@ public class ShortcutManagerView extends ViewPrototype implements ShortcutManage
                                         // note: workaround for resize bug
                                         table.setValueAt(shortcutText, rowIndex, vColIndex);
                                     }
-                                    component.setBackground(VitcoSettings.EDIT_BG_COLOR);
+                                    component.setBackground(shortcutManager.getEditBgColor(frame, rowIndex));
                                 } else { // this shortcut is already used (!)
                                     // show error color for one second
                                     component.setBackground(VitcoSettings.EDIT_ERROR_BG_COLOR);
@@ -121,7 +125,7 @@ public class ShortcutManagerView extends ViewPrototype implements ShortcutManage
                                                 // no need to track this
                                                 // e1.printStackTrace();
                                             }
-                                            component.setBackground(VitcoSettings.EDIT_BG_COLOR);
+                                            component.setBackground(shortcutManager.getEditBgColor(frame, rowIndex));
                                         }
                                     }.start();
                                 }
@@ -141,7 +145,7 @@ public class ShortcutManagerView extends ViewPrototype implements ShortcutManage
             // NOTE: We can't use "setEditable" b/c then global shortcuts would not be deactivated
             component.setCaretColor(new Color(0, 0, 0, 0)); // hide the caret
             component.setCursor(Cursor.getDefaultCursor()); // just show the ordinary mouse cursor
-            component.setBackground(VitcoSettings.EDIT_BG_COLOR); // bg color when edit
+            component.setBackground(shortcutManager.getEditBgColor(frame, rowIndex)); // bg color when edit
             component.setForeground(VitcoSettings.EDIT_TEXT_COLOR); // set text color when edit
             return component;
         }

--- a/PS4k/src/com/vitco/settings/VitcoSettings.java
+++ b/PS4k/src/com/vitco/settings/VitcoSettings.java
@@ -79,6 +79,7 @@ public final class VitcoSettings {
 
     // e.g. for shortcut manager
     public static final Color EDIT_BG_COLOR = new Color(250, 250, 250); // new Color(187, 209, 255);
+    public static final Color EDIT_BG_COLOR_HIGHLIGHT = new Color(250, 223, 78);
     public static final Color EDIT_TEXT_COLOR = new Color(30, 30, 30); // new Color(0, 0, 0);
     public static final Color EDIT_ERROR_BG_COLOR = new Color(255, 171, 161); // new Color(255,200,200);
     public static final Color DEFAULT_TEXT_COLOR = new Color(233,233,233);


### PR DESCRIPTION
Allow for global and frame shortcut collision. Frame shortcuts supersede global shortcuts
Note: this is nice to e.g. define ctrl + z for color palette undo in the future