### PR TITLE
Make the linux shortcut script show a more specific error message

### DIFF
--- a/static/install-linux.sh
+++ b/static/install-linux.sh
@@ -3,15 +3,15 @@
 me=`basename $0`
 echo "Installing VoxelShop..."
 
-customDie() {
+customExit() {
     echo
     echo "ERROR:"
     echo " $1"
     echo
     echo
-    ret=1
-    if [ ! -z $2 ]; then ret=$2; fi
-    exit $ret
+    code=1
+    if [ ! -z $2 ]; then code=$2; fi
+    exit $code
 }
 
 # region environment checks
@@ -58,55 +58,86 @@ fi
 
 bin_name=voxelshop
 dest_dir_name=voxelshop
-dest_dir_path=$PREFIX/lib/$dest_dir_name
+programs_path=$PREFIX/lib
+dest_dir_path=$programs_path/$dest_dir_name
 install_src=`pwd`
 lib_jar_name=voxelshop-start.jar
 lib_jar_path=$install_src/$lib_jar_name
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
+# ^ from https://stackoverflow.com/a/246128/4541104
 
 if [ ! -f "$lib_jar_path" ]; then
-    customDie "You must run $me in same path as built $lib_jar_name."
+    customExit "You must run $me in same path as built $lib_jar_name."
 fi
 icon_img_name=voxelshop.png
 icon_img_path=$install_src/share/pixmaps/icon-48x48.png
+
+if [ ! -f "$icon_img_path" ]; then
+    try_icon_path="$SCRIPT_DIR/share/pixmaps/icon-48x48.png"
+    if [ -f "$try_icon_path" ]; then
+        echo "INFO: $icon_img_path wasn't present, so $try_icon_path will be used instead."
+        icon_img_path="$try_icon_path"
+    fi
+fi
 if [ ! -f "$icon_img_path" ]; then
     echo "WARNING: Missing '$icon_img_path' (shortcut will have no icon image)"
 fi
 shortcut_name=com.blackflux.voxelshop.desktop
 shortcut_path=$install_src/share/applications/$shortcut_name
-
+if [ ! -f "$shortcut_path" ]; then
+    try_shortcut_path="$SCRIPT_DIR/share/applications/$shortcut_name"
+    if [ -f "$try_shortcut_path" ]; then
+        echo "INFO: $shortcut_path wasn't present, so $try_shortcut_path will be used instead."
+        shortcut_path="$try_shortcut_path"
+    fi
+fi
 # endregion hardcoded settings
 
 if [ ! -d $PREFIX/lib ]; then
-    mkdir -p $PREFIX/lib || customDie "Cannot create $PREFIX/lib"
+    mkdir -p $PREFIX/lib || customExit "Cannot create $PREFIX/lib"
 fi
 
 if [ ! -d $PREFIX/bin ]; then
-    mkdir -p $PREFIX/bin || customDie "Cannot create $PREFIX/bin"
+    mkdir -p $PREFIX/bin || customExit "Cannot create $PREFIX/bin"
 fi
 
 if [ ! -d "$dest_dir_path/lib" ]; then
     msg="Cannot create '$dest_dir_path/lib'"
-    mkdir -p $dest_dir_path/lib || customDie "$msg"
+    mkdir -p $dest_dir_path/lib || customExit "$msg"
 fi
 
 if [ ! -d "$dest_dir_path/share/applications" ]; then
     msg="Cannot create '$dest_dir_path/share/applications'"
-    mkdir -p $dest_dir_path/share/applications || customDie "$msg"
+    mkdir -p $dest_dir_path/share/applications || customExit "$msg"
 fi
 install_log_name=install.log
 install_log=$dest_dir_path/$install_log_name
 if [ -f "$install_log" ]; then
     # stopping in this case avoids creating a faulty install_log that
     # may contain files the user added to the directory.
-    customDie "The program is already installed. Run uninstall-linux.sh or delete $dest_dir_path before trying to reinstall."
+    customExit "The program is already installed. Run uninstall-linux.sh or delete $dest_dir_path before trying to reinstall."
 fi
-cp -f $install_src/* $dest_dir_path/
+
+if [ -d "$dest_dir_path" ]; then
+    echo "WARNING: \"$dest_dir_path\" already exists but there is no install log. The directory will be upgraded (any prepackaged files that remain will be overwritten)."
+fi
+
+# cp -f $install_src/* $dest_dir_path/
+cp -R $install_src $programs_path/
+# ^ dest_dir_path can't be used for cp -R, otherwise if it exists, the
+#   folder will be copied inside the dest instead of as the dest.
+
 find $dest_dir_path | grep -v "$install_log_name" > $install_log
 if [ ! -f "$install_log" ]; then
-    customDie "Cancelling install since cannot create $install_log."
+    customExit "Cancelling install since cannot create $install_log."
 fi
-cp -f $install_src/lib/* $dest_dir_path/lib/
-find $dest_dir_path | grep -v "$install_log_name" >> $install_log
+
+if [ ! -d "$dest_dir_path/lib" ]; then
+    customExit "lib wasn't copied, so install could not complete."
+fi
+# cp -f $install_src/lib/* $dest_dir_path/lib/
+# find $dest_dir_path | grep -v "$install_log_name" >> $install_log
+
 echo
 if [ -f "$bin_name" ]; then
     echo "Rewriting $bin_name..."
@@ -114,24 +145,50 @@ else
     echo "Writing $bin_name..."
 fi
 echo '#!/bin/sh' > $PREFIX/bin/$bin_name
-echo "java -jar $dest_dir_path/$lib_jar_name || notify-send \"Install openjdk-8-jre (Ubuntu), java-1.8.0-openjdk (Fedora), or another version of Java with GUI support.\"" >> $PREFIX/bin/$bin_name
+cat >>$PREFIX/bin/$bin_name <<END
+
+JAVA_GUI_PACKAGES="openjdk-8-jre (Ubuntu), java-1.8.0-openjdk (Fedora)"
+if [ ! -f "\`command -v java\`" ]; then
+    xmessage "VoxelShop Error: Java was not found. Install \$JAVA_GUI_PACKAGES, or another version of Java with GUI support."
+    exit 127  # 127 is for command not found.
+fi
+logs_dir="\$HOME/.var/log/voxelshop"
+mkdir -p "\$logs_dir"
+java -jar $dest_dir_path/$lib_jar_name > \$logs_dir/last_run.log 2>&1
+code=\$?
+if [ \$code -ne 0 ]; then
+    date > \$logs_dir/last_run.err
+    echo "VoxelShop exited with error code \$code:" >> \$logs_dir/last_run.err
+
+    echo >> \$logs_dir/last_run.err
+    echo "Ensure you have a java package with GUI support such as:" >> \$logs_dir/last_run.err
+    echo "\$JAVA_GUI_PACKAGES." >> $logs_dir/last_run.err
+    echo "The exact error will be shown below" >> \$logs_dir/last_run.err
+    echo "(ignore incorrect sRGB profile and canberra-gtk-module):" >> \$logs_dir/last_run.err
+
+    echo >> \$logs_dir/last_run.err
+    cat \$logs_dir/last_run.log >> \$logs_dir/last_run.err
+    xmessage -file \$logs_dir/last_run.err
+fi
+END
+# ^ INFO: >& only works with bash, so use 1>&2
 echo "$PREFIX/bin/$bin_name" >> $install_log
 chmod +x $PREFIX/bin/$bin_name
 if [ -f $shortcut_path ]; then
     #tmp_shortcut=/tmp/$USER$shortcut_name
     tmp_shortcut=$dest_dir_path/share/applications/$shortcut_name
     if [ -f $tmp_shortcut ]; then
-        rm $tmp_shortcut || customDie "Cannot remove old $tmp_shortcut"
+        rm $tmp_shortcut || customExit "Cannot remove old $tmp_shortcut"
     fi
     cat $shortcut_path | grep -v "Icon=" | grep -v "Exec=" | grep -v "Path=" > $tmp_shortcut
     echo "$tmp_shortcut" >> $install_log
     if [ ! -f $tmp_shortcut ]; then
-        customDie "Cannot rewrite $tmp_shortcut."
+        customExit "Cannot rewrite $tmp_shortcut."
     fi
     echo Exec=$PREFIX/bin/$bin_name >> $tmp_shortcut
     if [ -f $icon_img_path ]; then
         if [ ! -d $PREFIX/share/pixmaps ]; then
-            mkdir -p $PREFIX/share/pixmaps || customDie "Cannot create $PREFIX/share/pixmaps"
+            mkdir -p $PREFIX/share/pixmaps || customExit "Cannot create $PREFIX/share/pixmaps"
         fi
         if [ ! -d $PREFIX/share/pixmaps ]; then
             echo "ERROR: cannot create $PREFIX/share/pixmaps, so not installing graphic for icon"
@@ -140,50 +197,74 @@ if [ -f $shortcut_path ]; then
             echo Icon=$PREFIX/share/pixmaps/$icon_img_name >> $tmp_shortcut
         fi
         if [ ! -d $PREFIX/share/applications ]; then
-            mkdir -p "$PREFIX/share/applications" || customDie "Cannot create $PREFIX/share/applications."
+            mkdir -p "$PREFIX/share/applications" || customExit "Cannot create $PREFIX/share/applications."
         fi
         if [ -f $PREFIX/share/applications/$shortcut_name ]; then
-            rm -f $PREFIX/share/applications/$shortcut_name || customDie "Cannot remove old $PREFIX/share/applications/$shortcut_name."
+            rm -f $PREFIX/share/applications/$shortcut_name || customExit "Cannot remove old $PREFIX/share/applications/$shortcut_name."
         fi
         if [ -d $PREFIX/share/applications/$shortcut_name ]; then
-            rm -f $PREFIX/share/applications/$shortcut_name || customDie "Cannot remove bogus folder (should be file): $PREFIX/share/applications/$shortcut_name"
+            rm -f $PREFIX/share/applications/$shortcut_name || customExit "Cannot remove bogus folder (should be file): $PREFIX/share/applications/$shortcut_name"
         fi
         cp $tmp_shortcut $PREFIX/share/applications/$shortcut_name
         echo "$PREFIX/share/applications/$shortcut_name" >> $install_log
         echo "Writing shortcut '$PREFIX/share/applications/$shortcut_name' is complete."
         if [ "@$REFRESH_WM" = "@true" ]; then
             if [[ $EUID -ne 0 ]]; then
-                if [ -f "`command -v gnome-shell`" ]; then
+                THIS_DE=
+                # See <https://unix.stackexchange.com/a/645761/343286>
+                # regarding the old and new ways of checking what DE
+                # is running.
+                if [ ! -z "$XDG_SESSION_DESKTOP" ]; then
+                    THIS_DE=${XDG_SESSION_DESKTOP,,}  # convert to lower case
+                elif [ ! -z "$XDG_CURRENT_DESKTOP" ]; then
+                    THIS_DE=${XDG_CURRENT_DESKTOP,,}  # convert to lower case
+                fi
+                if [ "$THIS_DE" = "kde-plasma" ]; then
+                    THIS_DE="kde"
+                elif [ "$THIS_DE" = "xfce4" ]; then
+                    THIS_DE="xfce"
+                fi
+
+                # if [ -f "`command -v gnome-shell`" ]; then
+                if [ "$THIS_DE" = "gnome" ]; then
                     echo "* refreshing Gnome icons..."
                     gnome-shell --replace & disown
                     sleep 10
-                fi
-                if [ -f "$HOME/.cache/icon-cache.kcache" ]; then
-                    echo "* clearing $HOME/.cache/icon-cache.kcache..."
-                    rm $HOME/.cache/icon-cache.kcache
-                fi
-                if [ -f "`command -v kquitapp5`" ]; then
+                # if [ -f "`command -v kquitapp5`" ]; then
+                elif [ "$THIS_DE" = "kde" ]; then
+                    if [ -f "$HOME/.cache/icon-cache.kcache" ]; then
+                        echo "* clearing $HOME/.cache/icon-cache.kcache..."
+                        rm $HOME/.cache/icon-cache.kcache
+                    fi
                     echo "* refreshing KDE icons..."
                     if [ "`command -v kstart5`" ]; then
                         kquitapp5 plasmashell && kstart5 plasmashell && sleep 15 || echo " - skipping plasmashell icon refresh (session not loaded)"
                     else
                         kquitapp5 plasmashell && kstart plasmashell && sleep 15 || echo " - skipping plasmashell icon refresh (session not loaded)"
                     fi
-                fi
-                if [ -f "`command -v xfce4-panel`" ]; then
+                # if [ -f "`command -v xfce4-panel`" ]; then
+                elif [ "$THIS_DE" = "xfce" ]; then
                     echo "* refreshing Xfce icons..."
-                    xfce4-panel -r && xfwm4 --replace
+                    xfce4-panel -r && xfwm4 --replace & disown
                     sleep 5
-                fi
-                if [ -f "`command -v lxpanelctl`" ]; then
+                # if [ -f "`command -v lxpanelctl`" ]; then
+                elif [ "$THIS_DE" = "lxde" ]; then
                     echo "* refreshing LXDE icons..."
-                    lxpanelctl restart && openbox --restart
+                    lxpanelctl restart && openbox --restart & disown
                     sleep 5
-                fi
-                if [ -f "`command -v lxqt-panel`" ]; then
+                # if [ -f "`command -v lxqt-panel`" ]; then
+                elif [ "$THIS_DE" = "lxqt" ]; then
                     echo "* refreshing LXQt icons..."
-                    killall lxqt-panel && lxqt-panel &
+                    killall lxqt-panel && lxqt-panel & disown
+                elif [ "$THIS_DE" = "mate" ]; then
+                    echo "* refreshing MATE icons..."
+                    mate-panel --replace & disown
+                    sleep 3
+                else
+                    echo "WARNING: You may have to restart your panel to see the new shortcut. Your desktop environment \"$THIS_DE\" is unknown, so please report the issue along with this full message."
                 fi
+                # ^ Sleep commands ensure that the panel gets through its startup phase so console spam from the panel doesn't appear after the "Install is complete" message shown below.
+
             else
                echo "Since running as root, this script will not update application menus for any currently logged in user(s)."
             fi
@@ -194,5 +275,4 @@ if [ -f $shortcut_path ]; then
 else
     echo "WARNING: cannot add shortcut since missing $shortcut_path."
 fi
-
 echo "Install is complete."

--- a/static/install-linux.sh
+++ b/static/install-linux.sh
@@ -153,6 +153,9 @@ if [ ! -f "\`command -v java\`" ]; then
     exit 127  # 127 is for command not found.
 fi
 logs_dir="\$HOME/.var/log/voxelshop"
+if [ -f "\$logs_dir/last_run.err" ]; then
+    rm "\$logs_dir/last_run.err"
+fi
 mkdir -p "\$logs_dir"
 java -jar $dest_dir_path/$lib_jar_name > \$logs_dir/last_run.log 2>&1
 code=\$?
@@ -171,7 +174,8 @@ if [ \$code -ne 0 ]; then
     xmessage -file \$logs_dir/last_run.err
 fi
 END
-# ^ INFO: >& only works with bash, so use 1>&2
+# ^ NOTE: >& only works with bash, so use 1>&2
+# ^ NOTE: any file(s) written above should also be placed in the uninstall script.
 echo "$PREFIX/bin/$bin_name" >> $install_log
 chmod +x $PREFIX/bin/$bin_name
 if [ -f $shortcut_path ]; then

--- a/static/uninstall-linux.sh
+++ b/static/uninstall-linux.sh
@@ -63,11 +63,13 @@ else
     echo "  file in itself (this is not ideal, as entries after it may"
     echo "  have been lost, leading to incomplete uninstall)"
 fi
+echo "rmdir \"$PREFIX/lib/$dest_dir_name/share/applications\""
 rmdir "$PREFIX/lib/$dest_dir_name/share/applications"
+echo "rmdir \"$PREFIX/lib/$dest_dir_name/share\""
 rmdir "$PREFIX/lib/$dest_dir_name/share"
+echo "rmdir \"$PREFIX/lib/$dest_dir_name/lib\""
 rmdir "$PREFIX/lib/$dest_dir_name/lib"
-# echo "deleting uninstall.sh..."
-# rm "$PREFIX/lib/$dest_dir_name/uninstall.sh"
+echo "rmdir \"$PREFIX/lib/$dest_dir_name\""
 rmdir "$PREFIX/lib/$dest_dir_name"
 # Statements below won't do anything bad--they only remove dir if empty.
 rmdir --ignore-fail-on-non-empty "$PREFIX/share/applications"
@@ -80,8 +82,8 @@ fi
 if [ -f "$HOME/.var/log/voxelshop/last_run.log" ]; then
     rm "$HOME/.var/log/voxelshop/last_run.log"
 fi
-rmdir --ignore-fail-on-non-empty "$HOME/.var/log/voxelshop"
-rmdir --ignore-fail-on-non-empty "$HOME/.var/log"
-rmdir --ignore-fail-on-non-empty "$HOME/.var"
+rmdir --ignore-fail-on-non-empty "$HOME/.var/log/voxelshop" > /dev/null 2>&1
+rmdir --ignore-fail-on-non-empty "$HOME/.var/log" > /dev/null 2>&1
+rmdir --ignore-fail-on-non-empty "$HOME/.var" > /dev/null 2>&1
 
 echo "Uninstall is complete."

--- a/static/uninstall-linux.sh
+++ b/static/uninstall-linux.sh
@@ -74,6 +74,14 @@ rmdir --ignore-fail-on-non-empty "$PREFIX/share/applications"
 rmdir --ignore-fail-on-non-empty "$PREFIX/share/pixmaps"
 rmdir --ignore-fail-on-non-empty "$PREFIX/share"
 rmdir --ignore-fail-on-non-empty "$PREFIX/lib"
-rmdir --ignore-fail-on-non-empty "$PREFIX/bin"
+if [ -f "$HOME/.var/log/voxelshop/last_run.err" ]; then
+    rm "$HOME/.var/log/voxelshop/last_run.err"
+fi
+if [ -f "$HOME/.var/log/voxelshop/last_run.log" ]; then
+    rm "$HOME/.var/log/voxelshop/last_run.log"
+fi
+rmdir --ignore-fail-on-non-empty "$HOME/.var/log/voxelshop"
+rmdir --ignore-fail-on-non-empty "$HOME/.var/log"
+rmdir --ignore-fail-on-non-empty "$HOME/.var"
 
 echo "Uninstall is complete."


### PR DESCRIPTION
Hi, I made the original install and uninstall scripts, and this is an improved version with the following changes:
- Don't assume every error is that java is not installed.
  - Check for the `java` command first and show that specific error instead of running the program.
  - If the program runs but has a bad exit code, create and show a full, dated error log (`~/var/log/voxelshop/last_run.err`) from the output (`~/var/log/voxelshop/last_run.log`)
  - Clean up the irrelevant err file on run, and remove both log files (and directories if empty) on uninstall.
  - Use xmessage instead of notify-send so the user doesn't miss the error message and can copy&paste it (also, [xmessage is from xorg](https://gitlab.freedesktop.org/xorg/app/xmessage) so it works on virtually any desktop environment).
- More reliably ensure the correct panel is restarted (check for `XDG_SESSION_DESKTOP` or `XDG_CURRENT_DESKTOP` instead of relying on trial & error with `killall`).
- Detect the static files in case not running from the static directory (for testing or other scenarios when static's contents aren't in the unzipped release folder from which the script must run). This change allows running the install script using an absolute path as long as the working directory contains the jar files and the install script is in the same folder as "share". For example, run the script using its full path the repo directory when the current directory is the unzipped directory of the latest zip release.